### PR TITLE
Add highlightToday prop to highlight today's column in week view

### DIFF
--- a/src/.stories/Calendar.jsx
+++ b/src/.stories/Calendar.jsx
@@ -38,6 +38,22 @@ storiesOf('module.Calendar.week', module)
     )
   })
 
+  .add('highlighting today', () => {
+    return (
+      <div style={{height: 600}}>
+        <Calendar
+          defaultView="week"
+          highlightToday
+          min={moment('12:00am', 'h:mma').toDate()}
+          max={moment('11:59pm', 'h:mma').toDate()}
+          events={events}
+          onSelectEvent={action('event selected')}
+          defaultDate={new Date()}
+        />
+      </div>
+    )
+  })
+
   .add('selectable', () => {
     return (
       <div style={{height: 600}}>

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -141,6 +141,11 @@ let Calendar = React.createClass({
     popup: PropTypes.bool,
 
     /**
+     * Determines whether the column representing today is highlighted.
+     */
+    highlightToday: PropTypes.bool,
+
+    /**
      * Distance in pixels, from the edges of the viewport, the "show more" overlay should be positioned.
      *
      * ```js
@@ -326,6 +331,7 @@ let Calendar = React.createClass({
     return {
       popup: false,
       toolbar: true,
+      highlightToday: false,
       view: views.MONTH,
       views: [views.MONTH, views.WEEK, views.DAY, views.AGENDA],
       date: now,

--- a/src/TimeColumn.jsx
+++ b/src/TimeColumn.jsx
@@ -13,6 +13,7 @@ export default class TimeColumn extends Component {
     min: PropTypes.instanceOf(Date).isRequired,
     max: PropTypes.instanceOf(Date).isRequired,
     showLabels: PropTypes.bool,
+    highlightToday: PropTypes.bool,
     timeGutterFormat: PropTypes.string,
     type: PropTypes.string.isRequired,
     className: PropTypes.string
@@ -21,6 +22,7 @@ export default class TimeColumn extends Component {
     step: 30,
     timeslots: 2,
     showLabels: false,
+    highlightToday: false,
     type: 'day',
     className: ''
   }
@@ -63,9 +65,18 @@ export default class TimeColumn extends Component {
       date = next
     }
 
+    const classes = cn(
+      this.props.className,
+      'rbc-time-column',
+      {
+        'rbc-today': dates.isToday(this.props.max),
+        'rbc-highlight': this.props.highlightToday
+      }
+    )
+
     return (
       <div
-        className={cn(this.props.className, 'rbc-time-column')}
+        className={classes}
         style={this.props.style}
       >
         {timeslots}

--- a/src/less/time-column.less
+++ b/src/less/time-column.less
@@ -75,3 +75,7 @@
 .rbc-day-slot .rbc-event {
   position: absolute;
 }
+
+.rbc-day-slot.rbc-today.rbc-highlight {
+  background-color: @today-highlight-background;
+}

--- a/src/less/variables.less
+++ b/src/less/variables.less
@@ -24,3 +24,5 @@
 @btn-border: #ccc;
 
 @rbc-css-prefix: rbc-i;
+
+@today-highlight-background: #eaf6ff;

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -97,6 +97,10 @@ let dates = Object.assign(dateMath, {
     return dates.eq(dateA, dateB, 'month')
   },
 
+  isToday(date) {
+    return dates.eq(date, dates.today(), 'day')
+  },
+
   eqTime(dateA, dateB){
     return dates.hours(dateA) === dates.hours(dateB)
       && dates.minutes(dateA) === dates.minutes(dateB)


### PR DESCRIPTION
Adds a `highlightToday` optional prop (defaults to `false`) that enables highlighting of today's column in the week view.

Here is a screenshot from the storybook:
![screen shot 2016-07-01 at 4 08 53 pm](https://cloud.githubusercontent.com/assets/2531751/16670003/e2336b86-445d-11e6-8262-4158804530d3.png)
